### PR TITLE
Fixed warnings & changed number of taps

### DIFF
--- a/TapToScroll.h
+++ b/TapToScroll.h
@@ -16,7 +16,7 @@
 }
 
 
-@property (nonatomic) UITapGestureRecognizer *recognizer;
+@property (nonatomic, retain) UITapGestureRecognizer *recognizer;
 
 
 -(void) initListener:(CDVInvokedUrlCommand*)command;

--- a/TapToScroll.m
+++ b/TapToScroll.m
@@ -28,7 +28,7 @@
   if (!initialized) {
     
     UITapGestureRecognizer *tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapped:)];
-    [tapRecognizer setNumberOfTapsRequired:2];
+    [tapRecognizer setNumberOfTapsRequired:1];
     [tapRecognizer setNumberOfTouchesRequired:1];
     [self setRecognizer:tapRecognizer];
     [overlay setFrame:CGRectMake(0, 0, [UIApplication sharedApplication].statusBarFrame.size.width, [UIApplication sharedApplication].statusBarFrame.size.height)];

--- a/TapToScroll.m
+++ b/TapToScroll.m
@@ -32,7 +32,6 @@
     [tapRecognizer setNumberOfTouchesRequired:1];
     [self setRecognizer:tapRecognizer];
     [overlay setFrame:CGRectMake(0, 0, [UIApplication sharedApplication].statusBarFrame.size.width, [UIApplication sharedApplication].statusBarFrame.size.height)];
-    UIView *test = [[UIView alloc] initWithFrame:CGRectMake(0, 0, [UIApplication sharedApplication].statusBarFrame.size.width, [UIApplication sharedApplication].statusBarFrame.size.height)];
     
 
     overlay.windowLevel = UIWindowLevelStatusBar+1.f;


### PR DESCRIPTION
Thanks for a great plugin!
xcode threw some warning when building so I fixed them :)

Also the number of status bar taps required to scroll is usually just one (e.g. safari, mail, facebook) so I changed that as well
