### PR TITLE
Fix wrong statusBar position at app start and status bar transformation.

### DIFF
--- a/TapToScroll.m
+++ b/TapToScroll.m
@@ -58,6 +58,8 @@
     [[[overlay rootViewController] view] setFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height)];
     [[[overlay rootViewController] view] setBackgroundColor:[UIColor clearColor]];
 
+    [self rotateToStatusBarFrame];
+
     [[[overlay rootViewController] view] addGestureRecognizer:[self recognizer]];
     [self setupRotationListener];
     [overlay setClipsToBounds:YES];

--- a/TapToScroll.m
+++ b/TapToScroll.m
@@ -102,10 +102,10 @@
     overlay.transform = CGAffineTransformMakeRotation(pi * (90.f) / 180.0f);
     overlay.frame = [UIApplication sharedApplication].statusBarFrame;
   }else if (orientation == UIDeviceOrientationLandscapeRight) {
-    overlay.transform = CGAffineTransformMakeRotation(pi * (90.f) / 180.0f);
+    overlay.transform = CGAffineTransformMakeRotation(-pi * (90.f) / 180.0f);
     overlay.frame = [UIApplication sharedApplication].statusBarFrame;
   }else if (orientation == UIDeviceOrientationPortraitUpsideDown) {
-    overlay.transform = CGAffineTransformMakeRotation(pi);
+    overlay.transform = CGAffineTransformMakeRotation(-pi);
     overlay.frame = [UIApplication sharedApplication].statusBarFrame;
   }
   overlay.windowLevel = UIWindowLevelStatusBar+1.f;


### PR DESCRIPTION
Hi, I fixed a bug where the status bar was not set correctly when the orientation at app start was Landscape Right or Portrait U/D. I think the x and y axis are inverted in that case.

Anyway, I also changed the transformations so that the statusBar stays at the same place when switching to Landscape Right and Portrait U/D (it was rotating backward in those cases).
