### PR TITLE
Fixed compatibility with Cordova 2.7.0

### DIFF
--- a/taptoscroll.js
+++ b/taptoscroll.js
@@ -3,7 +3,7 @@ var TapToScroll = function() {
 }
 
 TapToScroll.prototype.initListener = function() {
-  cordova.exec("TapToScroll.initListener");
+cordova.exec(null, null, "TapToScroll", "initListener",[]);
 };
 
 if(!window.plugins) {


### PR DESCRIPTION
Fixed compatibility with Cordova 2.7.0
The old format of this exec call has been removed (deprecated since 2.1).
